### PR TITLE
Rename to rack-honeycomb for consistency with other honeycombio projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ For more information about using Honeycomb, check out our [docs](https://honeyco
 
 ```ruby
 # config/application.rb
-require 'rack/honey'
+require 'rack/honeycomb'
 
 class Application < Rails::Application
-  config.middleware.use Rack::Honey::Middleware, writekey: "<YOUR WRITEKEY HERE>", dataset: "<YOUR DATASET NAME HERE>"
+  config.middleware.use Rack::Honeycomb::Middleware, writekey: "<YOUR WRITEKEY HERE>", dataset: "<YOUR DATASET NAME HERE>"
 end
 ```
 
@@ -20,29 +20,29 @@ end
 ```ruby
 #!/usr/bin/env ruby -rubygems
 require 'sinatra'
-require 'rack/honey'
+require 'rack/honeycomb'
 
-use Rack::Honey::Middleware, writekey: "<YOUR WRITEKEY HERE>", dataset: "<YOUR DATASET NAME HERE>"
+use Rack::Honeycomb::Middleware, writekey: "<YOUR WRITEKEY HERE>", dataset: "<YOUR DATASET NAME HERE>"
 
 get('/hello') { "Hello, world!\n" }
 ```
 
 ## Installation
 
-To install the latest stable release of `rack-honey`, simply:
+To install the latest stable release of `rack-honeycomb`, simply:
 
 ```bash
-$ gem install rack-honey
+$ gem install rack-honeycomb
 ```
 
 or add this to your Gemfile
 
 ```
-gem "rack-honey"
+gem "rack-honeycomb"
 ```
 
 To follow the bleeding edge, it's easy to track the git repo:
 
 ```
-gem "rack-honey", :git => "https://github.com/honeycombio/rack-honey.git"
+gem "rack-honeycomb", :git => "https://github.com/honeycombio/rack-honeycomb.git"
 ```

--- a/lib/rack/honey.rb
+++ b/lib/rack/honey.rb
@@ -1,7 +1,0 @@
-require 'rack'
-
-module Rack
-  module Honey
-    autoload :Middleware, ::File.expand_path(::File.dirname(__FILE__)) + '/honey/middleware'
-  end
-end

--- a/lib/rack/honey/version.rb
+++ b/lib/rack/honey/version.rb
@@ -1,5 +1,0 @@
-module Rack
-  module Honey
-    VERSION="0.0.11"
-  end
-end

--- a/lib/rack/honeycomb.rb
+++ b/lib/rack/honeycomb.rb
@@ -1,0 +1,7 @@
+require 'rack'
+
+module Rack
+  module Honeycomb
+    autoload :Middleware, ::File.expand_path(::File.dirname(__FILE__)) + '/honeycomb/middleware'
+  end
+end

--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -1,7 +1,7 @@
 require "libhoney"
 
 module Rack
-  module Honey
+  module Honeycomb
 
     class Middleware
       attr_reader :app
@@ -16,7 +16,7 @@ module Rack
       def initialize(app, options = {})
         @app, @options = app, options
 
-        @honey = Libhoney::Client.new(:writekey => options[:writekey],
+        @honeycomb = Libhoney::Client.new(:writekey => options[:writekey],
                                       :dataset  => options[:dataset],
                                       :api_host => options[:api_host])
       end
@@ -24,13 +24,13 @@ module Rack
       def add_field(ev, field, value)
         ev.add_field(field, value) if value != nil && value != ''
       end
-      
+
       def add_env(ev, env, field)
         add_field(ev, field, env[field])
       end
 
       def call(env)
-        ev = @honey.event
+        ev = @honeycomb.event
         request_started_at = Time.now
         status, headers, response = @app.call(env)
         request_ended_at = Time.now

--- a/lib/rack/honeycomb/version.rb
+++ b/lib/rack/honeycomb/version.rb
@@ -1,0 +1,5 @@
+module Rack
+  module Honeycomb
+    VERSION="0.0.12"
+  end
+end

--- a/rack-honeycomb.gemspec
+++ b/rack-honeycomb.gemspec
@@ -3,14 +3,14 @@
 
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "rack/honey/version"
+require "rack/honeycomb/version"
 
 Gem::Specification.new do |spec|
-  spec.name               = 'rack-honey'
-  spec.version            = Rack::Honey::VERSION
+  spec.name               = 'rack-honeycomb'
+  spec.version            = Rack::Honeycomb::VERSION
   spec.date               = "2016-11-17"
 
-  spec.homepage           = 'https://github.com/honeycombio/rack-honey'
+  spec.homepage           = 'https://github.com/honeycombio/rack-honeycomb'
   spec.license            = 'Apache-2.0'
   spec.summary            = 'Rack middleware for logging request data to Honeycomb.'
   spec.description        = 'Rack middleware for logging request data to Honeycomb.'


### PR DESCRIPTION
If this looks ok, I'll also rename the repo and update the github ui description.