### PR TITLE
Support arbitrary metadata via `env`

### DIFF
--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -3,12 +3,11 @@ require "libhoney"
 module Rack
   module Honeycomb
     # Prefix for attaching arbitrary metadata to the `env`. Will be deleted from
-    # from the `env` once it's pulled off of the `env` and onto a Honeycomb
-    # event.
-    HEADER_PREFIX = "honeycomb_"
+    # the `env` once it's pulled off of the `env` and onto a Honeycomb event.
+    ENV_PREFIX = "honeycomb."
 
     class Middleware
-      HEADER_REGEX = /^#{ HEADER_PREFIX }/
+      HEADER_REGEX = /^#{ Regexp.escape ENV_PREFIX }/
 
       attr_reader :app
       attr_reader :options
@@ -52,7 +51,7 @@ module Rack
         # Pull arbitrary metadata off `env` if the caller attached anything
         # inside the Rack handler.
         env.each_pair do |k, v|
-          if k.start_with?(HEADER_PREFIX)
+          if k.is_a?(String) && k.match(HEADER_REGEX)
             add_field(ev, k.sub(HEADER_REGEX, ''), v)
             env.delete(k)
           end


### PR DESCRIPTION
Per chitchat in Slack - folks are going to want to be able to augment the default Rack payload when using this gem.

Thoughts on testing =\ or cleaner ways to do this very welcome.