### PR TITLE
Libhoney client should be initialized in a more threadsafe/reliable way

### DIFF
--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -20,10 +20,12 @@ module Rack
       # @option options [String]  :api_host   (nil)
       def initialize(app, options = {})
         @app, @options = app, options
+      end
 
-        @honeycomb = Libhoney::Client.new(:writekey => options[:writekey],
-                                      :dataset  => options[:dataset],
-                                      :api_host => options[:api_host])
+      def honeycomb
+        Thread.current[:honeycomb_client] ||= Libhoney::Client.new(:writekey => @options[:writekey],
+                                                                   :dataset  => @options[:dataset],
+                                                                   :api_host => @options[:api_host])
       end
 
       def add_field(ev, field, value)
@@ -35,7 +37,7 @@ module Rack
       end
 
       def call(env)
-        ev = @honeycomb.event
+        ev = honeycomb.event
         request_started_at = Time.now
         status, headers, response = @app.call(env)
         request_ended_at = Time.now


### PR DESCRIPTION
_This may be particular to a use case in which the engineers plug Rack middleware into Faraday 🤔, BUT_

We're seeing a case in which the middleware `initialize` is called on every request, which is resulting in no events being sent to Honeycomb. What I suspect is happening is that the client is initialized on each request (they weren't calling `.close` on it, which they shouldn't be doing per-request anyway), and then the client was trashed at the end of the request before flushing its internal queue of events.

No idea if this is idiomatic Ruby or kosher :)