### PR TITLE
Cleanup, nicer field names, meta fields, tests!

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 require 'bump/tasks'
+require 'rspec/core/rake_task'
 require 'yard'
 
 YARD::Rake::YardocTask.new(:doc)
 
-task default: :doc
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require 'bump/tasks'
+require 'yard'
+
+YARD::Rake::YardocTask.new(:doc)
+
+task default: :doc

--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -52,17 +52,14 @@ module Rack
 
         add_request_fields(ev, env)
 
-        request_started_at = Time.now
+        start = Time.now
         status, headers, body = adding_span_metadata_if_available(ev, env) do
           @app.call(env)
         end
-        request_ended_at = Time.now
 
         add_app_fields(ev, env)
 
         add_response_fields(ev, status, headers, body)
-
-        ev.add_field('duration_ms', (request_ended_at - request_started_at) * 1000)
 
         [status, headers, body]
       rescue Exception => e
@@ -72,7 +69,10 @@ module Rack
         end
         raise
       ensure
-        if ev
+        if ev && start
+          finish = Time.now
+          ev.add_field('duration_ms', (finish - start) * 1000)
+
           ev.send
         end
       end

--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -12,9 +12,6 @@ module Rack
       ENV_REGEX = /^#{ Regexp.escape ENV_PREFIX }/
       USER_AGENT_SUFFIX = "rack-honeycomb/#{VERSION}"
 
-      attr_reader :app
-      attr_reader :options
-
       ##
       # @param  [#call]                       app
       # @param  [Hash{Symbol => Object}]      options

--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -71,8 +71,6 @@ module Rack
 
       private
       def add_request_fields(event, env)
-        event.add_field('name', "#{env['REQUEST_METHOD']} #{env['PATH_INFO']}")
-
         event.add_field('request.method', env['REQUEST_METHOD'])
         event.add_field('request.path', env['PATH_INFO'])
         event.add_field('request.protocol', env['rack.url_scheme'])

--- a/rack-honeycomb.gemspec
+++ b/rack-honeycomb.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'rack', '>= 1.0.0'
   spec.add_runtime_dependency     'libhoney',  '>= 1.5.0'
+  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'yard'
 end

--- a/rack-honeycomb.gemspec
+++ b/rack-honeycomb.gemspec
@@ -31,9 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bump"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "webmock", "~> 2.1"
-  spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "yardstick", "~> 0.9"
   spec.add_development_dependency 'rack', '>= 1.0.0'
   spec.add_runtime_dependency     'libhoney',  '>= 1.5.0'
   spec.add_development_dependency 'rack-test'

--- a/spec/middleware/middleware_spec.rb
+++ b/spec/middleware/middleware_spec.rb
@@ -104,4 +104,22 @@ RSpec.describe Rack::Honeycomb::Middleware do
       )
     end
   end
+
+  describe 'Rack::Honeycomb.add_field' do
+    let(:app) do
+      base_app = lambda do |env|
+        Rack::Honeycomb.add_field(env, :hovercraft_contents, 'eels')
+        [200, {}, ['hello']]
+      end
+      with_middleware(base_app)
+    end
+
+    before { get '/' }
+
+    let(:event) { emitted_event }
+
+    it 'includes user-supplied fields, namespaced under "app"' do
+      expect(event.data).to include('app.hovercraft_contents' => 'eels')
+    end
+  end
 end

--- a/spec/middleware/middleware_spec.rb
+++ b/spec/middleware/middleware_spec.rb
@@ -1,0 +1,90 @@
+require 'libhoney'
+
+require 'rack/honeycomb/middleware'
+
+RSpec.describe Rack::Honeycomb::Middleware do
+  let(:fakehoney) { Libhoney::TestClient.new }
+  def with_middleware(app)
+    Rack::Honeycomb::Middleware.new(app, client: fakehoney)
+  end
+
+  let(:app) do
+    base_app = ->(_) { [200, {}, ['narf']] }
+    with_middleware(base_app)
+  end
+
+  def emitted_event
+    events = fakehoney.events
+    expect(events.size).to eq(1)
+    events[0]
+  end
+
+  it 'does not interfere with the app running' do
+    get '/'
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to eq('narf')
+  end
+
+  describe 'after the app processes a request' do
+    before { get '/' }
+    let(:event) { emitted_event }
+
+    it 'includes basic request and response fields' do
+      expect(event.data).to include(
+        'request.method' => 'GET',
+        'request.path' => '/',
+        'request.protocol' => 'http',
+        'response.status_code' => 200,
+      )
+    end
+
+    it 'records how long request processing took' do
+      expect(event.data).to include('duration_ms')
+      expect(event.data['duration_ms']).to be_a Numeric
+    end
+  end
+
+  describe 'more detailed request fields' do
+    before do
+      get 'https://search.example.org/', {q: 'bees', password: 'secret'}, {'REMOTE_ADDR' => '127.1.2.3'}
+    end
+
+    subject { emitted_event.data }
+
+    it { is_expected.to include('request.protocol' => 'https') }
+
+    it { is_expected.to include('request.host' => 'search.example.org') }
+
+    it { is_expected.to include('request.remote_addr' => '127.1.2.3') }
+
+    it 'records the querystring' do
+      expect(subject).to include('request.query_string' => 'q=bees&password=secret')
+      # no masking of sensitive params yet!
+    end
+  end
+
+  describe 'exception handling' do
+    let(:app) do
+      base_app = ->(_) { raise RuntimeError, 'kaboom!' }
+      with_middleware(base_app)
+    end
+
+    before do
+      expect { get '/explode' }.to raise_error RuntimeError
+    end
+
+    let(:event) { emitted_event }
+
+    it 'still includes request fields' do
+      expect(event.data).to include('request.method', 'request.path', 'request.protocol')
+    end
+
+    it 'captures exceptions' do
+      expect(event.data).to include(
+        'request.error' => 'RuntimeError',
+        'request.error_detail' => 'kaboom!',
+      )
+    end
+  end
+end

--- a/spec/middleware/middleware_spec.rb
+++ b/spec/middleware/middleware_spec.rb
@@ -1,4 +1,5 @@
 require 'libhoney'
+require 'socket'
 
 require 'rack/honeycomb/middleware'
 
@@ -30,6 +31,13 @@ RSpec.describe Rack::Honeycomb::Middleware do
     before { get '/' }
     let(:event) { emitted_event }
 
+    it 'sends an http_request event' do
+      expect(event.data).to include(
+        'type' => 'http_request',
+        'name' => 'GET /',
+      )
+    end
+
     it 'includes basic request and response fields' do
       expect(event.data).to include(
         'request.method' => 'GET',
@@ -43,6 +51,13 @@ RSpec.describe Rack::Honeycomb::Middleware do
       expect(event.data).to include('duration_ms')
       expect(event.data['duration_ms']).to be_a Numeric
     end
+
+    it 'includes meta fields in the event' do
+      expect(event.data).to include(
+        'meta.package' => 'rack',
+        'meta.package_version' => '1.3',
+      )
+    end
   end
 
   describe 'more detailed request fields' do
@@ -53,6 +68,8 @@ RSpec.describe Rack::Honeycomb::Middleware do
     subject { emitted_event.data }
 
     it { is_expected.to include('request.protocol' => 'https') }
+
+    it { is_expected.to include('local_hostname' => Socket.gethostname) }
 
     it { is_expected.to include('request.host' => 'search.example.org') }
 

--- a/spec/middleware/middleware_spec.rb
+++ b/spec/middleware/middleware_spec.rb
@@ -97,6 +97,11 @@ RSpec.describe Rack::Honeycomb::Middleware do
       expect(event.data).to include('request.method', 'request.path', 'request.protocol')
     end
 
+    it 'still includes duration' do
+      expect(event.data).to include('duration_ms')
+      expect(event.data['duration_ms']).to be_a Numeric
+    end
+
     it 'captures exceptions' do
       expect(event.data).to include(
         'request.error' => 'RuntimeError',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,57 @@
+require 'rack/test'
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.filter_run_when_matching :focus
+
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
+  config.disable_monkey_patching!
+
+  config.warnings = true
+
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = "doc"
+  end
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
Assorted cleanup and rationalisation, and adding tests. Drops the SHOUTY_FIELD_NAMES in favour of the naming conventions we're establishing for Beelines (though should make sense for anyone using this middleware outside of the Beeline too), and drops some fields outright that weren't particularly useful (e.g. `SERVER_SOFTWARE`, `rack.run_once`). (See the individual commit messages for more details of what's changed.)

This change should be API-backward-compatible (existing apps using the middleware continue to work) but not schema-backward-compatible (their events will have different fields and field names). I'm pretty sure nobody is using this right now, and anyway the gem version is `< 0.1` :) (Although I'll probably bless an 0.1.0 release after merging this.)