### PR TITLE
Rails support (and better Sinatra support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ build-iPhoneSimulator/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-Gemfile.lock
+Gemfile*.lock
 .ruby-version
 .ruby-gemset
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ Gemfile.lock
 .rvmrc
 
 *~
+log

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+gemfile:
+  - Gemfile
+  - Gemfile.rails3.rb
+  - Gemfile.rails4.rb
 deploy:
   provider: rubygems
   gem: rack-honeycomb

--- a/Gemfile.rails3.rb
+++ b/Gemfile.rails3.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec
+
+gem 'rails', '< 4'
+gem 'test-unit', '~> 3.0'

--- a/Gemfile.rails4.rb
+++ b/Gemfile.rails4.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec
+
+gem 'rails', '< 5'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Attaching the middleware is simple. Inside handlers, you also have the choice of
 require 'sinatra'
 require 'rack/honeycomb'
 
-use Rack::Honeycomb::Middleware, writekey: "<YOUR WRITEKEY HERE>", dataset: "<YOUR DATASET NAME HERE>"
+use Rack::Honeycomb::Middleware, writekey: "<YOUR WRITEKEY HERE>", dataset: "<YOUR DATASET NAME HERE>", is_sinatra: true
 
 get('/hello') do
   Rack::Honeycomb.add_field env, :greeting, 'hello'

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If honeycomb-rails doesn't work for you, this Rack middleware should work for Ra
 require 'rack/honeycomb'
 
 class Application < Rails::Application
-  config.middleware.use Rack::Honeycomb::Middleware, writekey: "<YOUR WRITEKEY HERE>", dataset: "<YOUR DATASET NAME HERE>"
+  config.middleware.use Rack::Honeycomb::Middleware, writekey: "<YOUR WRITEKEY HERE>", dataset: "<YOUR DATASET NAME HERE>", is_rails: true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ require 'rack/honeycomb'
 use Rack::Honeycomb::Middleware, writekey: "<YOUR WRITEKEY HERE>", dataset: "<YOUR DATASET NAME HERE>"
 
 get('/hello') do
-  Rack::Honeycomb.add_field :greeting, 'hello'
+  Rack::Honeycomb.add_field env, :greeting, 'hello'
   "Hello, world!\n"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ end
 
 ## Adding instrumentation to a Rails application
 
-For more fully-featured Rails support, see [honeycomb-rails](https://github.com/honeycombio/honeycomb-rails).
+For more fully-featured Rails support, see [beeline-ruby](https://github.com/honeycombio/beeline-ruby).
 
-If honeycomb-rails doesn't work for you, this Rack middleware should work for Rails apps too:
+[beeline-ruby](https://github.com/honeycombio/beeline-ruby) includes this gem along with active record support.
+
+If beeline-ruby doesn't work for you, you can include this middleware standalone
 
 ```ruby
 # config/application.rb

--- a/lib/rack-honeycomb/auto_install.rb
+++ b/lib/rack-honeycomb/auto_install.rb
@@ -37,7 +37,7 @@ module Rack
             if !AutoInstall.already_added
               AutoInstall.debug "Adding Rack::Honeycomb::Middleware to #{self}"
 
-              self.use Rack::Honeycomb::Middleware, client: honeycomb_client, logger: logger
+              self.use Rack::Honeycomb::Middleware, client: honeycomb_client, logger: logger, is_sinatra: true
               AutoInstall.already_added = true
             else
               # In the case of nested Sinatra apps - apps composed of other apps

--- a/lib/rack-honeycomb/auto_install.rb
+++ b/lib/rack-honeycomb/auto_install.rb
@@ -83,7 +83,7 @@ module Rack
           @logger.debug "#{self.name}: #{msg}" if @logger
         end
 
-        def warn(*args)
+        def warn(msg)
           @logger.warn "#{self.name}: #{msg}" if @logger
         end
 

--- a/lib/rack-honeycomb/railtie.rb
+++ b/lib/rack-honeycomb/railtie.rb
@@ -1,0 +1,26 @@
+require 'rails'
+
+module Rack
+  module Honeycomb
+    class Railtie < ::Rails::Railtie
+      class << self
+        attr_reader :honeycomb_client, :logger
+
+        def init(honeycomb_client:, logger: nil)
+          @honeycomb_client = honeycomb_client
+          @logger = logger
+
+          logger.debug "#{self}: initialized with #{honeycomb_client.class}" if logger
+        end
+      end
+
+      initializer 'honeycomb.add_rack_middleware' do |app|
+        app.middleware.use ::Rack::Honeycomb::Middleware,
+          client: Railtie.honeycomb_client,
+          logger: Railtie.logger,
+          is_rails: true
+        Railtie.logger.debug "#{Railtie}: Added rack-honeycomb middleware to #{app.class}" if Railtie.logger
+      end
+    end
+  end
+end

--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -136,7 +136,6 @@ module Rack
       end
 
       def add_rails_fields(event, env)
-        # TODO what minimum Rails version does this need?
         rails_params = env['action_dispatch.request.parameters']
         unless rails_params.kind_of? Hash
           debug "Got unexpected type #{rails_params.class} for env['action_dispatch.request.parameters']"

--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -97,6 +97,7 @@ module Rack
 
       def add_request_fields(event, env)
         event.add_field('name', "#{env['REQUEST_METHOD']} #{env['PATH_INFO']}")
+        # N.B. 'name' may be overwritten later by add_sinatra_fields
 
         event.add_field('request.method', env['REQUEST_METHOD'])
         event.add_field('request.path', env['PATH_INFO'])
@@ -113,7 +114,10 @@ module Rack
       end
 
       def add_sinatra_fields(event, env)
-        event.add_field('request.route', env['sinatra.route'])
+        route = env['sinatra.route']
+        event.add_field('request.route', route)
+        # overwrite 'name' (previously set in add_request_fields)
+        event.add_field('name', route)
       end
 
       def add_app_fields(event, env)

--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -51,8 +51,6 @@ module Rack
             'meta.local_hostname' => Socket.gethostname,
           )
 
-        @service_name = options.delete(:service_name) || :rack
-
         @is_sinatra = options.delete(:is_sinatra)
         debug 'Enabling Sinatra-specific fields' if @is_sinatra
       end

--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -73,13 +73,6 @@ module Rack
           @app.call(env)
         end
 
-        # TODO seems to need to be called _after_ processing the request. Would
-        # be better if we could do it before. Can we do that by changing
-        # middleware order?
-        add_sinatra_fields(ev, env) if @is_sinatra
-
-        add_app_fields(ev, env)
-
         add_response_fields(ev, status, headers, body)
 
         [status, headers, body]
@@ -93,6 +86,10 @@ module Rack
         if ev && start
           finish = Time.now
           ev.add_field('duration_ms', (finish - start) * 1000)
+
+          add_sinatra_fields(ev, env) if @is_sinatra
+
+          add_app_fields(ev, env)
 
           ev.send
         end

--- a/rack-honeycomb.gemspec
+++ b/rack-honeycomb.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     'libhoney',  '>= 1.5.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rack-test'
+  spec.add_development_dependency 'rails'
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'pry-byebug'

--- a/spec/middleware/plain_rack_spec.rb
+++ b/spec/middleware/plain_rack_spec.rb
@@ -3,9 +3,6 @@ require 'socket'
 
 require 'rack/honeycomb/middleware'
 
-require 'support/shared_examples_for_middleware'
-
-
 RACK_APP = lambda do |env|
   case env['PATH_INFO']
   when '/'

--- a/spec/middleware/plain_rack_spec.rb
+++ b/spec/middleware/plain_rack_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "#{Rack::Honeycomb::Middleware} with plain Rack app" do
     expect(last_response.body).to eq('narf')
   end
 
-  include_examples 'Rack::Honeycomb::Middleware'
+  include_examples 'Rack::Honeycomb::Middleware', package: 'rack', package_version: ::Rack::VERSION.join('.')
 
   describe 'URL patterns' do
     # Pure Rack does not define any routing mechanism and thus doesn't have a

--- a/spec/middleware/plain_rack_spec.rb
+++ b/spec/middleware/plain_rack_spec.rb
@@ -15,6 +15,8 @@ RACK_APP = lambda do |env|
   when '/annotated'
     Rack::Honeycomb.add_field(env, :hovercraft_contents, 'eels')
     [200, {}, ['hello']]
+  when %r{^/hello/(\w+)$}
+    [200, {}, ["Hello #{$1}"]]
   else
     [404, {}, ['what?']]
   end
@@ -35,4 +37,26 @@ RSpec.describe "#{Rack::Honeycomb::Middleware} with plain Rack app" do
   end
 
   include_examples 'Rack::Honeycomb::Middleware'
+
+  describe 'URL patterns' do
+    # Pure Rack does not define any routing mechanism and thus doesn't have a
+    # notion of "URL patterns". The test app above includes an example
+    # routing implementation using a regex. This test just serves as
+    # documentation that we don't (and can't) do anything clever with the URLs
+    # in this case. Contrast with sinatra_spec where we report the URL pattern
+    # from the route rather than the literal URL.
+
+    before { get '/hello/Honeycomb' }
+
+    it 'reports the actual URL requested, not the URL pattern declared in the app' do
+      expect(last_response.body).to eq('Hello Honeycomb') # sanity check the test app
+
+      expect(emitted_event.data).to include('request.path' => '/hello/Honeycomb')
+      expect(emitted_event.data).to_not include('request.route')
+    end
+
+    it 'uses the HTTP verb and path as the "name" field of the event' do
+      expect(emitted_event.data).to include('name' => 'GET /hello/Honeycomb')
+    end
+  end
 end

--- a/spec/middleware/plain_rack_spec.rb
+++ b/spec/middleware/plain_rack_spec.rb
@@ -11,6 +11,7 @@ RACK_APP = lambda do |env|
   when '/'
     [200, {}, ['narf']]
   when '/explode'
+    Rack::Honeycomb.add_field(env, :email, 'test@example.com')
     raise 'kaboom!'
   when '/annotated'
     Rack::Honeycomb.add_field(env, :hovercraft_contents, 'eels')

--- a/spec/middleware/rails_spec.rb
+++ b/spec/middleware/rails_spec.rb
@@ -25,7 +25,11 @@ class TestApp < Rails::Application
     get '/explode', to: 'hello#explode'
     get '/explosions/:message', to: 'hello#explode'
 
-    root 'hello#index'
+    if Rails::VERSION::MAJOR < 4
+      root to: 'hello#index'
+    else
+      root 'hello#index'
+    end
   end
 end
 

--- a/spec/middleware/rails_spec.rb
+++ b/spec/middleware/rails_spec.rb
@@ -1,0 +1,211 @@
+require 'rails'
+require 'action_controller/railtie'
+
+require 'libhoney'
+
+require 'rack/honeycomb/middleware'
+
+class TestApp < Rails::Application
+  FAKEHONEY = Libhoney::TestClient.new
+
+  middleware.use Rack::Honeycomb::Middleware, client: FAKEHONEY, is_rails: true
+
+  # some minimal config Rails expects to be present
+  if Rails::VERSION::MAJOR < 4
+    config.secret_token = 'test' * 8
+  else
+    config.secret_key_base = 'test'
+  end
+
+  config.eager_load = true
+
+  routes.append do
+    get '/hello/:name', to: 'hello#show'
+    get '/annotated', to: 'hello#annotated'
+    get '/explode', to: 'hello#explode'
+    get '/explosions/:message', to: 'hello#explode'
+
+    root 'hello#index'
+  end
+end
+
+class HelloController < ActionController::Base
+  def index
+    render_plain 'Hello world!'
+  end
+
+  def annotated
+    Rack::Honeycomb.add_field(request.env, :hovercraft_contents, 'eels')
+    render_plain 'hello'
+  end
+
+  def show
+    render_plain "Hello #{params[:name]}"
+  end
+
+  def explode
+    Rack::Honeycomb.add_field(request.env, :email, 'test@example.com')
+    message = params[:message] || 'kaboom!'
+    raise message
+  end
+
+  private
+  def render_plain(text)
+    if Rails::VERSION::MAJOR < 4
+      render text: text
+    else
+      render plain: text
+    end
+  end
+end
+
+if Rails::VERSION::MAJOR >= 5
+  class TestAPIApp < Rails::Application
+    FAKEHONEY = Libhoney::TestClient.new
+
+    config.api_only = true
+
+    middleware.use Rack::Honeycomb::Middleware, client: FAKEHONEY, is_rails: true
+
+    # some minimal config Rails expects to be present
+    config.secret_key_base = 'test'
+
+    config.eager_load = true
+
+    routes.append do
+      get '/hello/:name', to: 'hello_api#show'
+      get '/annotated', to: 'hello_api#annotated'
+      get '/explode', to: 'hello_api#explode'
+      get '/explosions/:message', to: 'hello_api#explode'
+
+      root 'hello_api#index'
+    end
+  end
+
+  class HelloApiController < ActionController::API
+    def index
+      render json: {status: 'ok', greeting: 'Hello world!'}
+    end
+
+    def annotated
+      Rack::Honeycomb.add_field(request.env, :hovercraft_contents, 'eels')
+      render json: {status: 'ok'}
+    end
+
+    def show
+      render json: {status: 'ok', greeting: "Hello #{params[:name]}!"}
+    end
+
+    def explode
+      Rack::Honeycomb.add_field(request.env, :email, 'test@example.com')
+      message = params[:message] || 'kaboom!'
+      raise message
+    end
+  end
+end
+
+RSpec.shared_examples 'Rails app' do |controller:|
+  describe 'routing for a successful request' do
+    before { get '/hello/Honeycomb' }
+
+    it 'reports the declared route, as well as the actual URL requested' do
+      expect(last_response.body).to include('Hello Honeycomb') # sanity check the test app
+
+      expect(emitted_event.data).to include(
+        'request.path' => '/hello/Honeycomb',
+        'request.route' => 'GET /hello/:name',
+      )
+    end
+
+    it 'records the param values matched by the route' do
+      expect(emitted_event.data).to include('request.params.name' => 'Honeycomb')
+    end
+
+    it 'records the Rails controller and action that were invoked' do
+      expect(emitted_event.data).to include(
+        'request.controller' => controller,
+        'request.action' => 'show',
+      )
+    end
+
+    it 'uses the Rails controller action as the "name" field of the event' do
+      expect(emitted_event.data).to include('name' => "#{controller}#show")
+    end
+  end
+
+  describe 'routing for an erroring request' do
+    before { get '/explosions/oh_no' }
+
+    it 'reports the declared route, as well as the actual URL requested' do
+      expect(last_response).to_not be_ok # sanity check the test app
+
+      expect(emitted_event.data).to include(
+        'request.path' => '/explosions/oh_no',
+        'request.route' => 'GET /explosions/:message',
+      )
+    end
+
+    it 'records the param values matched by the route' do
+      expect(emitted_event.data).to include('request.params.message' => 'oh_no')
+    end
+
+    it 'records the Rails controller and action that were invoked' do
+      expect(emitted_event.data).to include(
+        'request.controller' => controller,
+        'request.action' => 'explode',
+      )
+    end
+
+    it 'uses the Rails controller action as the "name" field of the event' do
+      expect(emitted_event.data).to include('name' => "#{controller}#explode")
+    end
+  end
+end
+
+RSpec.describe "#{Rack::Honeycomb::Middleware} with Rails" do
+  before(:all) { TestApp.initialize! }
+
+  after(:each) { TestApp::FAKEHONEY.reset }
+
+  def fakehoney
+    TestApp::FAKEHONEY
+  end
+
+  let(:app) { TestApp }
+
+  it 'does not interfere with the app running' do
+    get '/'
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to eq('Hello world!')
+  end
+
+  include_examples 'Rack::Honeycomb::Middleware', package: 'rails', package_version: ::Rails::VERSION::STRING
+
+  include_examples 'Rails app', controller: 'hello'
+end
+
+if Rails::VERSION::MAJOR >= 5
+  RSpec.describe "#{Rack::Honeycomb::Middleware} with Rails in API-only mode" do
+    before(:all) { TestAPIApp.initialize! }
+
+    after(:each) { TestAPIApp::FAKEHONEY.reset }
+
+    def fakehoney
+      TestAPIApp::FAKEHONEY
+    end
+
+    let(:app) { TestAPIApp }
+
+    it 'does not interfere with the app running' do
+      get '/'
+
+      expect(last_response).to be_ok
+      expect(JSON.parse(last_response.body)).to include('greeting' => 'Hello world!')
+    end
+
+  include_examples 'Rack::Honeycomb::Middleware', package: 'rails', package_version: ::Rails::VERSION::STRING
+
+    include_examples 'Rails app', controller: 'hello_api'
+  end
+end

--- a/spec/middleware/sinatra_spec.rb
+++ b/spec/middleware/sinatra_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "#{Rack::Honeycomb::Middleware} with Sinatra" do
     expect(last_response.body).to eq('narf')
   end
 
-  include_examples 'Rack::Honeycomb::Middleware'
+  include_examples 'Rack::Honeycomb::Middleware', package: 'sinatra', package_version: ::Sinatra::VERSION
 
   describe 'URL patterns' do
     before { get '/hello/Honeycomb' }

--- a/spec/middleware/sinatra_spec.rb
+++ b/spec/middleware/sinatra_spec.rb
@@ -5,15 +5,19 @@ require 'rack/honeycomb/middleware'
 
 class SinatraApp < Sinatra::Base
   FAKEHONEY = Libhoney::TestClient.new
-  use Rack::Honeycomb::Middleware, client: FAKEHONEY
+  use Rack::Honeycomb::Middleware, client: FAKEHONEY, is_sinatra: true
 
   get('/') { 'narf' }
 
   get('/explode') { raise 'kaboom!' }
 
-  get('/annotated') do
+  get '/annotated' do
     Rack::Honeycomb.add_field(env, :hovercraft_contents, 'eels')
     'hello'
+  end
+
+  get '/hello/:name' do
+    "Hello #{params[:name]}"
   end
 end
 
@@ -34,4 +38,27 @@ RSpec.describe "#{Rack::Honeycomb::Middleware} with Sinatra" do
   end
 
   include_examples 'Rack::Honeycomb::Middleware'
+
+  describe 'URL patterns' do
+    before { get '/hello/Honeycomb' }
+
+    it 'reports the declared route, as well as the actual URL requested' do
+      expect(last_response.body).to eq('Hello Honeycomb') # sanity check the test app
+
+      expect(emitted_event.data).to include(
+        'request.path' => '/hello/Honeycomb',
+        'request.route' => 'GET /hello/:name',
+      )
+    end
+
+    it 'uses the URL pattern as the "name" field of the event' do
+      expect(emitted_event.data).to include('name' => 'GET /hello/:name')
+    end
+
+    it 'records the param values matched by the route' do
+      pending 'probably need to hook into Sinatra more deeply'
+
+      expect(emitted_event.data).to include('request.params.name' => 'Honeycomb')
+    end
+  end
 end

--- a/spec/rack-honeycomb/auto_install_spec.rb
+++ b/spec/rack-honeycomb/auto_install_spec.rb
@@ -1,0 +1,16 @@
+require "rack-honeycomb/auto_install"
+
+RSpec.describe Rack::Honeycomb::AutoInstall do
+  describe "Logging" do
+    it "Warning message is logged correctly" do
+      logger = double()
+      warn_message = "warning"
+
+      Rack::Honeycomb::AutoInstall.instance_variable_set(:@logger, logger)
+
+      expect(logger).to receive(:warn).with(/#{warn_message}/)
+
+      Rack::Honeycomb::AutoInstall.warn(warn_message)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'rack/test'
+require 'support/shared_examples_for_middleware'
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods

--- a/spec/support/shared_examples_for_middleware.rb
+++ b/spec/support/shared_examples_for_middleware.rb
@@ -70,6 +70,10 @@ RSpec.shared_examples 'Rack::Honeycomb::Middleware' do |package:, package_versio
       expect(emitted_event.data['duration_ms']).to be_a Numeric
     end
 
+    it 'still includes user-supplied fields' do
+      expect(emitted_event.data).to include('app.email' => 'test@example.com')
+    end
+
     it 'captures exceptions' do
       expect(emitted_event.data).to include(
         'request.error' => 'RuntimeError',

--- a/spec/support/shared_examples_for_middleware.rb
+++ b/spec/support/shared_examples_for_middleware.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'Rack::Honeycomb::Middleware' do
+RSpec.shared_examples 'Rack::Honeycomb::Middleware' do |package:, package_version:|
   let(:emitted_event) do
     events = fakehoney.events
     expect(events.size).to eq(1)
@@ -28,8 +28,8 @@ RSpec.shared_examples 'Rack::Honeycomb::Middleware' do
 
     it 'includes meta fields in the event' do
       expect(emitted_event.data).to include(
-        'meta.package' => 'rack',
-        'meta.package_version' => '1.3',
+        'meta.package' => package,
+        'meta.package_version' => package_version,
       )
     end
   end

--- a/spec/support/shared_examples_for_middleware.rb
+++ b/spec/support/shared_examples_for_middleware.rb
@@ -9,10 +9,7 @@ RSpec.shared_examples 'Rack::Honeycomb::Middleware' do
     before { get '/' }
 
     it 'sends an http_server event' do
-      expect(emitted_event.data).to include(
-        'type' => 'http_server',
-        'name' => 'GET /',
-      )
+      expect(emitted_event.data).to include('type' => 'http_server')
     end
 
     it 'includes basic request and response fields' do


### PR DESCRIPTION
Improves this middleware's functionality when used with a Rails app, capturing the Rails controller, action and matched route pattern (in fields `request.controller`, `request.action` and `request.route`) and request params (in `request.params.*`) as well as the literal URL requested.

A few other improvements thrown in:

 * likewise captures `request.route` for Sinatra apps too (but not the request params, those aren't so easy to get at from a mere middleware)
 * fixes a bug where some fields weren't getting set if the request threw an exception
 * CI build tests on Rails versions 3 through 5