### PR TITLE
Remove params collection

### DIFF
--- a/lib/rack/honeycomb/middleware.rb
+++ b/lib/rack/honeycomb/middleware.rb
@@ -145,8 +145,6 @@ module Rack
         rails_params.each do |param, value|
           if RAILS_SPECIAL_PARAMS.include?(param)
             event.add_field("request.#{param}", value)
-          else
-            event.add_field("request.params.#{param}", value)
           end
         end
 

--- a/spec/middleware/rails_spec.rb
+++ b/spec/middleware/rails_spec.rb
@@ -121,10 +121,6 @@ RSpec.shared_examples 'Rails app' do |controller:|
       )
     end
 
-    it 'records the param values matched by the route' do
-      expect(emitted_event.data).to include('request.params.name' => 'Honeycomb')
-    end
-
     it 'records the Rails controller and action that were invoked' do
       expect(emitted_event.data).to include(
         'request.controller' => controller,
@@ -147,10 +143,6 @@ RSpec.shared_examples 'Rails app' do |controller:|
         'request.path' => '/explosions/oh_no',
         'request.route' => 'GET /explosions/:message',
       )
-    end
-
-    it 'records the param values matched by the route' do
-      expect(emitted_event.data).to include('request.params.message' => 'oh_no')
     end
 
     it 'records the Rails controller and action that were invoked' do

--- a/spec/middleware/sinatra_spec.rb
+++ b/spec/middleware/sinatra_spec.rb
@@ -59,12 +59,6 @@ RSpec.describe "#{Rack::Honeycomb::Middleware} with Sinatra" do
     it 'uses the URL pattern as the "name" field of the event' do
       expect(emitted_event.data).to include('name' => 'GET /hello/:name')
     end
-
-    it 'records the param values matched by the route' do
-      pending 'probably need to hook into Sinatra more deeply'
-
-      expect(emitted_event.data).to include('request.params.name' => 'Honeycomb')
-    end
   end
 
   describe 'URL patterns for an erroring request' do
@@ -79,12 +73,6 @@ RSpec.describe "#{Rack::Honeycomb::Middleware} with Sinatra" do
 
     it 'uses the URL pattern as the "name" field of the event' do
       expect(emitted_event.data).to include('name' => 'GET /explosions/:message')
-    end
-
-    it 'records the param values matched by the route' do
-      pending 'probably need to hook into Sinatra more deeply'
-
-      expect(emitted_event.data).to include('request.params.message' => 'oh_no')
     end
   end
 end


### PR DESCRIPTION
Collecting all of the params can cause issues with producing too many columns for a dataset. In the future we should provide a way to specify the relevant params for your application. For now though we will remove this feature.

Tagged everyone for review mostly as an FYI